### PR TITLE
Older bootstrap

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
     "popup"
   ],
   "dependencies" : {
-    "bootstrap": ">=3.2.0"
+    "bootstrap": ">=3.1.0"
   },
   "license": "Apache",
   "repository": {


### PR DESCRIPTION
it is necessary to have dependency only on newest version? I need it to older
