### PR TITLE
Update bootstrap-confirmation.js

### DIFF
--- a/bootstrap-confirmation.js
+++ b/bootstrap-confirmation.js
@@ -147,7 +147,7 @@
       .prepend($('<i></i>').addClass(o.btnOkIcon), ' ')
       .off('click')
       .one('click', function(e) {
-        that.getOnConfirm.call(that).call(that.$element);
+        that.getOnConfirm.call(that).call(that.$element, e);
         that.$element.trigger('confirmed.bs.confirmation');
         that.leave(that);
       });


### PR DESCRIPTION
this change allow 'onConfirm' handler receive event object (and use one handler for multiple elements).
not breaking current behaviour
