### PR TITLE
Restore tooltip state on 'hide'

### DIFF
--- a/bootstrap-confirmation.js
+++ b/bootstrap-confirmation.js
@@ -233,6 +233,10 @@
       }
       if (typeof option == 'string') {
         data[option]();
+        
+        if (option == 'hide' && data.inState) { //data.inState doesn't exist in Bootstrap < 3.3.5
+          data.inState.click = false;
+        }
       }
     });
   };


### PR DESCRIPTION
It fixes the issue when:
- configure a confirmation with 'popout : true' parameter,
- click on target element (confirmation is shown),
- click outside of confirmation (confirmation is hidden)
- click on target element again -> no confirmation is shown (but is show on next click).