### PR TITLE
Remove bootstrap from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,6 @@
       "homepage": "http://www.strangeplanet.fr"
     }
   ],
-  "dependencies" : {
-    "bootstrap": ">=3.2.0"
-  },
   "devDependencies": {
     "grunt": "^1.0.0",
     "grunt-contrib-connect": "^1.0.0",


### PR DESCRIPTION
I get that bootstrap is a required dependency for this library, but the actual package itself doesn't need it as far as I can tell. We actually use `bootstrap-sass` instead of `bootstrap`, but now installing this addon means we have to pull in two duplicate bootstrap installations for no reason.