### PR TITLE
Clean body click event on dispose

### DIFF
--- a/src/confirmation.js
+++ b/src/confirmation.js
@@ -223,6 +223,8 @@ class Confirmation extends Popover {
   }
 
   dispose() {
+    $('body').off(`${Event.CLICK}.${this.uid}`);
+    this.eventBody = false;
     this._cleanKeyupEvent();
     super.dispose();
   }


### PR DESCRIPTION
Hi, I use bootstrap-confirmation with marionette.js, and my component is as follows:

```js
import { View } from 'backbone.marionette';

class MyView extends View {
        
    onRender() {
        this.$el.find('[data-toggle="confirmation"]').confirmation({
            ...
        });
    }

    onBeforeDestroy() {
        this.$el.find('[data-toggle="confirmation"]').confirmation('dispose');
    }
}
```

As a result of user interaction or through a websocket view may be rerender. Will be called view `destroy` and confirm `dispose` methods, if at this time the confirmation dialog was opened body click event will live on:

![Screenshot from 2019-03-18 15-50-38](https://user-images.githubusercontent.com/13837747/54535072-ccbb5400-499e-11e9-84f8-ed7b774d516d.png)
