### PR TITLE
fix issue that custom buttons can't be mapped attributes from selector

### DIFF
--- a/src/confirmation.js
+++ b/src/confirmation.js
@@ -354,7 +354,7 @@ class Confirmation extends Popover {
         .addClass(BTN_CLASS_BASE)
         .addClass(button.class || `${BTN_CLASS_DEFAULT} btn-secondary`)
         .html(button.label || '')
-        .attr(button.attr || {});
+        .attr(button.attr || (button.cancel ? {} : self.config._attributes));
 
       if (button.iconClass || button.iconContent) {
         btn.prepend($('<i></i>')


### PR DESCRIPTION
When i use custom buttons to reserve order of buttons, i found that attr of buttons only be set static, what mean i can't map attributes from seletor to custom buttons.
